### PR TITLE
게시물 상세화면 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("com.google.gms.google-services")
     id("kotlin-parcelize")
-    id("androidx.navigation.safeargs")
+    id("androidx.navigation.safeargs.kotlin")
     id("kotlin-kapt")
     id("com.google.dagger.hilt.android")
     id("com.google.firebase.crashlytics")

--- a/app/src/main/java/com/wasingun/seller_lounge/data/datasource/PostDataSource.kt
+++ b/app/src/main/java/com/wasingun/seller_lounge/data/datasource/PostDataSource.kt
@@ -10,6 +10,11 @@ import kotlinx.coroutines.flow.Flow
 
 interface PostDataSource {
 
+    fun getPostList(
+        onComplete: () -> Unit,
+        onError: (String) -> Unit
+    ): Flow<List<PostInfo>>
+
     suspend fun postInfoUpload(
         postId: String,
         category: ProductCategory,
@@ -21,10 +26,7 @@ interface PostDataSource {
         userId: String
     ): ApiResponse<Unit>
 
-    fun getPostList(
-        onComplete: () -> Unit,
-        onError: (String) -> Unit
-    ): Flow<List<PostInfo>>
-
     suspend fun userInfoUpload(userId: String, userInfo: UserInfo): ApiResponse<Unit>
+
+    suspend fun getWriterInfo(userId: String):ApiResponse<UserInfo>
 }

--- a/app/src/main/java/com/wasingun/seller_lounge/data/datasource/PostRemoteDataSource.kt
+++ b/app/src/main/java/com/wasingun/seller_lounge/data/datasource/PostRemoteDataSource.kt
@@ -124,6 +124,10 @@ class PostRemoteDataSource @Inject constructor(private val postDataClient: PostD
         return postDataClient.uploadUserInfo(userId, userInfo)
     }
 
+    override suspend fun getWriterInfo(userId: String): ApiResponse<UserInfo> {
+        return postDataClient.getUserInfo(userId)
+    }
+
     private suspend fun getDownloadUrl(location: String): String {
         val firebaseStorage = FirebaseStorage.getInstance()
         return firebaseStorage.getReference(location)

--- a/app/src/main/java/com/wasingun/seller_lounge/data/model/post/PostInfo.kt
+++ b/app/src/main/java/com/wasingun/seller_lounge/data/model/post/PostInfo.kt
@@ -1,7 +1,10 @@
 package com.wasingun.seller_lounge.data.model.post
 
+import android.os.Parcelable
 import com.wasingun.seller_lounge.data.enums.ProductCategory
+import kotlinx.parcelize.Parcelize
 
+@Parcelize
 data class PostInfo(
     val postId: String,
     val category: ProductCategory,
@@ -11,4 +14,4 @@ data class PostInfo(
     val documentList: List<String>? = null,
     val createTime: String,
     val userId: String,
-)
+): Parcelable

--- a/app/src/main/java/com/wasingun/seller_lounge/data/repository/GeneralRepository.kt
+++ b/app/src/main/java/com/wasingun/seller_lounge/data/repository/GeneralRepository.kt
@@ -91,6 +91,10 @@ class GeneralRepository @Inject constructor(
         return result
     }
 
+    suspend fun getWriterInfo(userId: String): ApiResponse<UserInfo> {
+        return postDataSource.getWriterInfo(userId)
+    }
+
     suspend fun userInfoUploadResult(userId: String, userInfo: UserInfo): ApiResponse<Unit> {
         return postDataSource.userInfoUpload(userId, userInfo)
     }

--- a/app/src/main/java/com/wasingun/seller_lounge/extensions/ImageExtentions.kt
+++ b/app/src/main/java/com/wasingun/seller_lounge/extensions/ImageExtentions.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import android.widget.ImageView
 import androidx.databinding.BindingAdapter
 import coil.load
+import coil.transform.CircleCropTransformation
 import coil.transform.RoundedCornersTransformation
 
 @BindingAdapter("setRoundCornerImage")
@@ -37,5 +38,14 @@ fun ImageView.setRoundedCornerImage(imageAddress: Any?) {
 fun ImageView.setImageList(imageUrl: String?) {
     if (!imageUrl.isNullOrBlank()) {
         load(imageUrl)
+    }
+}
+
+@BindingAdapter("setCircleImage")
+fun ImageView.setCircleImage(imageUrl: String?) {
+    if (!imageUrl.isNullOrBlank()) {
+        load(imageUrl) {
+            transformations(CircleCropTransformation())
+        }
     }
 }

--- a/app/src/main/java/com/wasingun/seller_lounge/extensions/ImageExtentions.kt
+++ b/app/src/main/java/com/wasingun/seller_lounge/extensions/ImageExtentions.kt
@@ -7,26 +7,35 @@ import coil.load
 import coil.transform.RoundedCornersTransformation
 
 @BindingAdapter("setRoundCornerImage")
-fun ImageView.setRoundedCornerImage(uri: Uri) {
-    load(uri) {
-        transformations(
-            RoundedCornersTransformation(
-                10.0f
-            )
-        )
-        error(null)
+fun ImageView.setRoundedCornerImage(imageAddress: Any?) {
+    if (imageAddress != null) {
+        when(imageAddress) {
+            is Uri -> {
+                load(imageAddress) {
+                    transformations(
+                        RoundedCornersTransformation(
+                            10.0f
+                        )
+                    )
+                    error(null)
+                }
+            }
+            is String -> {
+                load(imageAddress) {
+                    transformations(
+                        RoundedCornersTransformation(
+                            10.0f
+                        )
+                    )
+                    error(null)
+                }
+            }
+        }
     }
 }
 
-@BindingAdapter("loadImageFromUrl")
-fun ImageView.loadImageFromUrl(url: String?) {
-    load(url) {
-        if (!url.isNullOrBlank()) {
-            transformations(
-                RoundedCornersTransformation(
-                    10.0f
-                )
-            )
-        }
+fun ImageView.setImageList(imageUrl: String?) {
+    if (!imageUrl.isNullOrBlank()) {
+        load(imageUrl)
     }
 }

--- a/app/src/main/java/com/wasingun/seller_lounge/network/PostDataClient.kt
+++ b/app/src/main/java/com/wasingun/seller_lounge/network/PostDataClient.kt
@@ -14,6 +14,9 @@ interface PostDataClient {
         @Body userInfo: UserInfo
     ): ApiResponse<Unit>
 
+    @GET("userInfo/{userId}.json")
+    suspend fun getUserInfo(@Path("userId") userId: String): ApiResponse<UserInfo>
+
     @PUT("postInfo/{postId}.json")
     suspend fun uploadPostContent(
         @Path("postId") postId: String,

--- a/app/src/main/java/com/wasingun/seller_lounge/ui/MainActivity.kt
+++ b/app/src/main/java/com/wasingun/seller_lounge/ui/MainActivity.kt
@@ -16,6 +16,7 @@ class MainActivity : AppCompatActivity() {
         R.id.dest_login,
         R.id.dest_trend_comparison_result,
         R.id.dest_post_content,
+        R.id.dest_post_detail
     )
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/wasingun/seller_lounge/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/wasingun/seller_lounge/ui/home/HomeFragment.kt
@@ -3,30 +3,54 @@ package com.wasingun.seller_lounge.ui.home
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.tabs.TabLayoutMediator
 import com.wasingun.seller_lounge.R
 import com.wasingun.seller_lounge.SellerLoungeApplication
 import com.wasingun.seller_lounge.data.enums.ProductCategory
 import com.wasingun.seller_lounge.databinding.FragmentHomeBinding
+import com.wasingun.seller_lounge.extensions.showTextMessage
 import com.wasingun.seller_lounge.ui.BaseFragment
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
+@AndroidEntryPoint
 class HomeFragment : BaseFragment<FragmentHomeBinding>() {
     private lateinit var adapter: HomeViewPagerAdapter
     private val sharedViewModel by viewModels<HomeSharedViewModel>()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        adapter = HomeViewPagerAdapter(this)
+        checkLoginState()
+        updateUserInfo()
+        binding.vpHome.adapter = adapter
+        binding.viewModel = sharedViewModel
         binding.btnPost.setOnClickListener {
             moveToPost()
         }
-        adapter = HomeViewPagerAdapter(this)
-        binding.vpHome.adapter = adapter
-        binding.viewModel = sharedViewModel
+        setViewPager()
+        lifecycleScope.launch {
+            sharedViewModel.isError.collect {errorMessage ->
+                if(errorMessage != 0) {
+                    binding.root.showTextMessage(errorMessage)
+                }
+            }
+        }
+    }
 
+    private fun setViewPager() {
         TabLayoutMediator(binding.tlTabMenu, binding.vpHome) { tab, position ->
             tab.text = ProductCategory.values()[position].categoryName
         }.attach()
+    }
+
+    private fun checkLoginState() {
+        if (SellerLoungeApplication.auth.currentUser == null) {
+            val action = HomeFragmentDirections.actionDestHomeToDestLogin()
+            findNavController().navigate(action)
+        }
     }
 
     private fun moveToPost() {
@@ -34,12 +58,8 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>() {
         findNavController().navigate(action)
     }
 
-    override fun onStart() {
-        super.onStart()
-        if (SellerLoungeApplication.auth.currentUser == null) {
-            val action = HomeFragmentDirections.actionDestHomeToDestLogin()
-            findNavController().navigate(action)
-        }
+    private fun updateUserInfo() {
+        sharedViewModel.updateUserInfo()
     }
 
     override fun getFragmentView(): Int {

--- a/app/src/main/java/com/wasingun/seller_lounge/ui/home/HomePostFragment.kt
+++ b/app/src/main/java/com/wasingun/seller_lounge/ui/home/HomePostFragment.kt
@@ -6,6 +6,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
 import com.wasingun.seller_lounge.R
 import com.wasingun.seller_lounge.data.enums.ProductCategory
 import com.wasingun.seller_lounge.databinding.LayoutHomePostBinding
@@ -19,9 +20,11 @@ import kotlinx.coroutines.launch
 @AndroidEntryPoint
 class HomePostFragment : BaseFragment<LayoutHomePostBinding>() {
 
-    private val adapter = HomePostAdapter(PostClickListener {
+    private val adapter = HomePostAdapter{postInfo ->
+        val action = HomeFragmentDirections.actionDestHomeToPostDetailFragment(postInfo)
+        findNavController().navigate(action)
+    }
 
-    })
     private val viewModel by viewModels<HomePostViewModel>()
     private val sharedViewModel by viewModels<HomeSharedViewModel>(
         ownerProducer = { requireParentFragment() }

--- a/app/src/main/java/com/wasingun/seller_lounge/ui/home/HomeSharedViewModel.kt
+++ b/app/src/main/java/com/wasingun/seller_lounge/ui/home/HomeSharedViewModel.kt
@@ -1,20 +1,52 @@
 package com.wasingun.seller_lounge.ui.home
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.wasingun.seller_lounge.R
+import com.wasingun.seller_lounge.SellerLoungeApplication
+import com.wasingun.seller_lounge.data.model.post.UserInfo
+import com.wasingun.seller_lounge.data.repository.GeneralRepository
+import com.wasingun.seller_lounge.network.onError
+import com.wasingun.seller_lounge.network.onException
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class HomeSharedViewModel @Inject constructor(): ViewModel() {
+class HomeSharedViewModel @Inject constructor(private val repository: GeneralRepository) :
+    ViewModel() {
 
+    private val _isError = MutableStateFlow(0)
+    val isError: StateFlow<Int> = _isError
     private val _searchButtonState = MutableStateFlow(false)
-    val searchButtonState:StateFlow<Boolean> = _searchButtonState
+    val searchButtonState: StateFlow<Boolean> = _searchButtonState
+
     val searchKeyword = MutableStateFlow("")
 
     fun searchTitle() {
         _searchButtonState.value = true
         _searchButtonState.value = false
+    }
+
+    fun updateUserInfo() {
+        viewModelScope.launch {
+            val currentUser = SellerLoungeApplication.auth.currentUser
+            val userId = currentUser?.uid ?: ""
+            val userName = currentUser?.displayName ?: ""
+            val userEmail = currentUser?.email ?: ""
+            val userImage = currentUser?.photoUrl.toString() ?: ""
+            val result = repository.userInfoUploadResult(
+                userId, UserInfo(userId, userName, userEmail, userImage)
+            )
+            result.onError { code, message ->
+                _isError.value = R.string.error_user_info_update
+                _isError.value = 0
+            }.onException {
+                _isError.value = R.string.error_api_network
+                _isError.value = 0
+            }
+        }
     }
 }

--- a/app/src/main/java/com/wasingun/seller_lounge/ui/home/PostClickListener.kt
+++ b/app/src/main/java/com/wasingun/seller_lounge/ui/home/PostClickListener.kt
@@ -1,8 +1,8 @@
 package com.wasingun.seller_lounge.ui.home
 
-import com.wasingun.seller_lounge.data.model.ImageContent
+import com.wasingun.seller_lounge.data.model.post.PostInfo
 
 fun interface PostClickListener {
 
-    fun clickPost(imageContent: ImageContent)
+    fun clickPost(postInfo: PostInfo)
 }

--- a/app/src/main/java/com/wasingun/seller_lounge/ui/postdetail/PostDetailFragment.kt
+++ b/app/src/main/java/com/wasingun/seller_lounge/ui/postdetail/PostDetailFragment.kt
@@ -1,0 +1,46 @@
+package com.wasingun.seller_lounge.ui.postdetail
+
+import android.os.Bundle
+import android.view.View
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
+import com.google.android.material.tabs.TabLayoutMediator
+import com.wasingun.seller_lounge.R
+import com.wasingun.seller_lounge.data.model.post.PostInfo
+import com.wasingun.seller_lounge.databinding.FragmentPostDetailBinding
+import com.wasingun.seller_lounge.ui.BaseFragment
+import com.wasingun.seller_lounge.util.convertDisplayedDate
+
+class PostDetailFragment : BaseFragment<FragmentPostDetailBinding>() {
+    private val args: PostDetailFragmentArgs by navArgs()
+    private val adapter = PostImageAdapter()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val postInfo = args.post
+
+        setLayout(postInfo)
+    }
+
+    private fun setLayout(postInfo: PostInfo) {
+        with(binding) {
+            tvTitle.text = postInfo.title
+            tvCategory.text = postInfo.category.categoryName
+            tvBody.text = postInfo.body
+            tvTime.convertDisplayedDate(postInfo.createTime)
+            vpImageList.adapter = adapter
+            btnArrow.setOnClickListener {
+                findNavController().navigateUp()
+            }
+        }
+        adapter.submitList(postInfo.imageList)
+
+        TabLayoutMediator(binding.tlCircleIndicator, binding.vpImageList) { tab, position ->
+
+        }.attach()
+    }
+
+    override fun getFragmentView(): Int {
+        return R.layout.fragment_post_detail
+    }
+}

--- a/app/src/main/java/com/wasingun/seller_lounge/ui/postdetail/PostDetailFragment.kt
+++ b/app/src/main/java/com/wasingun/seller_lounge/ui/postdetail/PostDetailFragment.kt
@@ -2,24 +2,55 @@ package com.wasingun.seller_lounge.ui.postdetail
 
 import android.os.Bundle
 import android.view.View
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.google.android.material.tabs.TabLayoutMediator
 import com.wasingun.seller_lounge.R
 import com.wasingun.seller_lounge.data.model.post.PostInfo
 import com.wasingun.seller_lounge.databinding.FragmentPostDetailBinding
+import com.wasingun.seller_lounge.extensions.setCircleImage
+import com.wasingun.seller_lounge.extensions.showTextMessage
 import com.wasingun.seller_lounge.ui.BaseFragment
 import com.wasingun.seller_lounge.util.convertDisplayedDate
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
+@AndroidEntryPoint
 class PostDetailFragment : BaseFragment<FragmentPostDetailBinding>() {
     private val args: PostDetailFragmentArgs by navArgs()
     private val adapter = PostImageAdapter()
+    private val viewModel: PostDetailViewModel by viewModels<PostDetailViewModel>()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val postInfo = args.post
-
+        getWriterInfo()
         setLayout(postInfo)
+        setWriterInfo()
+        lifecycleScope.launch {
+            viewModel.isError.collect{errorMessage ->
+                if(errorMessage != 0) {
+                    binding.root.showTextMessage(errorMessage)
+                }
+            }
+        }
+    }
+
+    private fun getWriterInfo() {
+        lifecycleScope.launch {
+            viewModel.getWriterInfo(args.post.userId)
+        }
+    }
+
+    private fun setWriterInfo() {
+        lifecycleScope.launch {
+            viewModel.writerInfo.collect { writerInfo ->
+                binding.tvUserName.text = writerInfo.userName
+                binding.ivProfileImage.setCircleImage(writerInfo.userImage)
+            }
+        }
     }
 
     private fun setLayout(postInfo: PostInfo) {
@@ -33,7 +64,11 @@ class PostDetailFragment : BaseFragment<FragmentPostDetailBinding>() {
                 findNavController().navigateUp()
             }
         }
-        adapter.submitList(postInfo.imageList)
+        if (postInfo.imageList.isNullOrEmpty()) {
+            binding.vpImageList.visibility = View.GONE
+        } else {
+            adapter.submitList(postInfo.imageList)
+        }
 
         TabLayoutMediator(binding.tlCircleIndicator, binding.vpImageList) { tab, position ->
 

--- a/app/src/main/java/com/wasingun/seller_lounge/ui/postdetail/PostDetailViewModel.kt
+++ b/app/src/main/java/com/wasingun/seller_lounge/ui/postdetail/PostDetailViewModel.kt
@@ -1,0 +1,35 @@
+package com.wasingun.seller_lounge.ui.postdetail
+
+import androidx.lifecycle.ViewModel
+import com.wasingun.seller_lounge.R
+import com.wasingun.seller_lounge.data.model.post.UserInfo
+import com.wasingun.seller_lounge.data.repository.GeneralRepository
+import com.wasingun.seller_lounge.network.onError
+import com.wasingun.seller_lounge.network.onException
+import com.wasingun.seller_lounge.network.onSuccess
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class PostDetailViewModel @Inject constructor(private val repository: GeneralRepository) :
+    ViewModel() {
+    private val _isError = MutableStateFlow(0)
+    val isError: StateFlow<Int> = _isError
+
+    private val _writerInfo = MutableStateFlow<UserInfo>(UserInfo("", "", "", ""))
+    val writerInfo: StateFlow<UserInfo> = _writerInfo
+    suspend fun getWriterInfo(userId: String) {
+        val result = repository.getWriterInfo(userId)
+        result.onSuccess {
+            _writerInfo.value = it
+        }.onError { _, _ ->
+            _isError.value = R.string.error_writer_info_load
+            _isError.value = 0
+        }.onException {
+            _isError.value = R.string.offline_mode
+            _isError.value = 0
+        }
+    }
+}

--- a/app/src/main/java/com/wasingun/seller_lounge/ui/postdetail/PostImageAdapter.kt
+++ b/app/src/main/java/com/wasingun/seller_lounge/ui/postdetail/PostImageAdapter.kt
@@ -1,0 +1,51 @@
+package com.wasingun.seller_lounge.ui.postdetail
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.wasingun.seller_lounge.databinding.ItemPostImageBinding
+import com.wasingun.seller_lounge.extensions.setImageList
+
+class PostImageAdapter() :
+    ListAdapter<String, PostImageAdapter.ImageBannerViewHolder>(DiffCallback()) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ImageBannerViewHolder {
+        return ImageBannerViewHolder.from(parent)
+    }
+
+    override fun onBindViewHolder(holder: ImageBannerViewHolder, position: Int) {
+        return holder.bind(getItem(position))
+    }
+
+    class ImageBannerViewHolder(private val binding: ItemPostImageBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(imageUrl: String) {
+            binding.ivPostImage.setImageList(imageUrl)
+        }
+
+        companion object {
+
+            fun from(parent: ViewGroup): PostImageAdapter.ImageBannerViewHolder {
+                val binding = ItemPostImageBinding.inflate(
+                    LayoutInflater.from(parent.context),
+                    parent,
+                    false
+                )
+                return ImageBannerViewHolder(binding)
+            }
+        }
+    }
+
+    private class DiffCallback : DiffUtil.ItemCallback<String?>() {
+        override fun areItemsTheSame(oldItem: String, newItem: String): Boolean {
+            return oldItem == newItem
+        }
+
+        override fun areContentsTheSame(oldItem: String, newItem: String): Boolean {
+            return oldItem == newItem
+        }
+    }
+}

--- a/app/src/main/res/drawable/ic_indicator_off.xml
+++ b/app/src/main/res/drawable/ic_indicator_off.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:innerRadius="0dp"
+    android:shape="ring"
+    android:thickness="3dp"
+    android:useLevel="false">
+
+    <solid android:color="@color/grey"/>
+</shape>

--- a/app/src/main/res/drawable/ic_indicator_on.xml
+++ b/app/src/main/res/drawable/ic_indicator_on.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:innerRadius="0dp"
+    android:shape="ring"
+    android:thickness="5dp"
+    android:useLevel="false">
+
+    <solid android:color="@color/deep_grey"/>
+</shape>

--- a/app/src/main/res/drawable/selector_indicator.xml
+++ b/app/src/main/res/drawable/selector_indicator.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_indicator_on" android:state_selected="true" />
+    <item android:drawable="@drawable/ic_indicator_off"/>
+</selector>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -35,7 +35,7 @@
             app:tabGravity="center"
             app:tabIndicatorHeight="1dp"
             app:tabMode="scrollable"
-            app:tabTextAppearance="@style/TabLayoutTitle" />
+            app:tabTextAppearance="@style/TabLayoutText" />
 
         <EditText
             android:id="@+id/et_search"

--- a/app/src/main/res/layout/fragment_post_detail.xml
+++ b/app/src/main/res/layout/fragment_post_detail.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <ImageButton
+            android:id="@+id/btn_arrow"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="14dp"
+            android:layout_marginTop="17dp"
+            android:backgroundTint="@color/clear"
+            android:padding="0dp"
+            android:src="@drawable/ic_arrow"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_category"
+            style="@style/TextLabel11"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:layout_marginTop="24dp"
+            android:background="@drawable/shape_reactangle_grey"
+            android:paddingHorizontal="10dp"
+            android:paddingVertical="3dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/btn_arrow"
+            tools:text="디지털/가전" />
+
+        <ImageView
+            android:id="@+id/iv_profile_image"
+            android:layout_width="34dp"
+            android:layout_height="34dp"
+            android:layout_marginStart="10dp"
+            android:layout_marginTop="12dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_category" />
+
+        <TextView
+            android:id="@+id/tv_user_name"
+            style="@style/TextTitle14"
+            android:layout_width="wrap_content"
+            android:layout_height="18dp"
+            android:layout_marginStart="11dp"
+            app:layout_constraintStart_toEndOf="@id/iv_profile_image"
+            app:layout_constraintTop_toTopOf="@id/iv_profile_image"
+            tools:text="와신군" />
+
+        <TextView
+            android:id="@+id/tv_time"
+            style="@style/TextLabelGrey11"
+            android:layout_width="wrap_content"
+            android:layout_height="16dp"
+            android:layout_marginStart="11dp"
+            app:layout_constraintBottom_toBottomOf="@id/iv_profile_image"
+            app:layout_constraintStart_toEndOf="@id/iv_profile_image"
+            tools:text="1시간 전" />
+
+        <TextView
+            android:id="@+id/tv_title"
+            style="@style/TextTitle14"
+            android:layout_width="wrap_content"
+            android:layout_height="20dp"
+            android:layout_marginStart="10dp"
+            android:layout_marginTop="16dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/iv_profile_image"
+            tools:text="겨울 신규상품 카다로그 드립니다." />
+
+        <androidx.viewpager2.widget.ViewPager2
+            android:id="@+id/vp_image_list"
+            android:layout_width="0dp"
+            android:layout_height="360dp"
+            android:layout_marginTop="10dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_title" />
+
+        <com.google.android.material.tabs.TabLayout
+            android:id="@+id/tl_circle_indicator"
+            android:layout_width="wrap_content"
+            android:layout_height="20dp"
+            app:layout_constraintBottom_toBottomOf="@id/vp_image_list"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            android:background="@color/clear"
+            app:tabBackground="@drawable/selector_indicator"
+            app:tabGravity="center"
+            app:tabIndicatorHeight="0dp" />
+
+        <TextView
+            android:id="@+id/tv_body"
+            style="@style/TextBody12"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="10dp"
+            android:layout_marginTop="10dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/vp_image_list"
+            tools:text="본문 내용" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_document_list"
+            android:layout_width="0dp"
+            android:layout_height="45dp"
+            android:layout_marginHorizontal="10dp"
+            android:layout_marginTop="10dp"
+            android:orientation="horizontal"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_body" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/app/src/main/res/layout/fragment_post_detail.xml
+++ b/app/src/main/res/layout/fragment_post_detail.xml
@@ -40,6 +40,7 @@
             android:layout_height="34dp"
             android:layout_marginStart="10dp"
             android:layout_marginTop="12dp"
+            android:scaleType="centerCrop"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_category" />
 
@@ -87,10 +88,10 @@
             android:id="@+id/tl_circle_indicator"
             android:layout_width="wrap_content"
             android:layout_height="20dp"
+            android:background="@color/clear"
             app:layout_constraintBottom_toBottomOf="@id/vp_image_list"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            android:background="@color/clear"
             app:tabBackground="@drawable/selector_indicator"
             app:tabGravity="center"
             app:tabIndicatorHeight="0dp" />

--- a/app/src/main/res/layout/item_home_post.xml
+++ b/app/src/main/res/layout/item_home_post.xml
@@ -18,7 +18,8 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="100dp">
+        android:layout_height="100dp"
+        android:onClick="@{() -> postClickListener.clickPost(postInfo)}">
 
         <TextView
             android:id="@+id/tv_category"
@@ -50,7 +51,7 @@
 
         <TextView
             android:id="@+id/tv_body"
-            style="@style/TextLabel11"
+            style="@style/TextLabelGrey11"
             android:layout_width="250dp"
             android:layout_height="16dp"
             android:layout_marginStart="10dp"
@@ -58,13 +59,12 @@
             android:ellipsize="end"
             android:maxLines="1"
             android:text="@{postInfo.body}"
-            android:textColor="@color/grey"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_title" />
 
         <TextView
             android:id="@+id/tv_time"
-            style="@style/TextLabel11"
+            style="@style/TextLabelGrey11"
             convertDisplayedDate="@{postInfo.createTime}"
             android:layout_width="wrap_content"
             android:layout_height="16dp"
@@ -72,7 +72,6 @@
             android:layout_marginTop="5dp"
             android:ellipsize="end"
             android:maxLines="1"
-            android:textColor="@color/grey"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_body" />
 
@@ -86,7 +85,7 @@
             app:layout_constraintStart_toStartOf="parent" />
 
         <ImageView
-            loadImageFromUrl="@{postInfo.imageList[0]}"
+            setRoundCornerImage="@{postInfo.imageList[0]}"
             android:layout_width="60dp"
             android:layout_height="60dp"
             android:layout_marginTop="10dp"

--- a/app/src/main/res/layout/item_post_image.xml
+++ b/app/src/main/res/layout/item_post_image.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <ImageView
+            android:id="@+id/iv_post_image"
+            android:layout_width="0dp"
+            android:layout_height="360dp"
+            android:scaleType="centerCrop"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>
+

--- a/app/src/main/res/navigation/main_graph.xml
+++ b/app/src/main/res/navigation/main_graph.xml
@@ -25,8 +25,12 @@
             app:popUpTo="@id/dest_login"
             app:popUpToInclusive="true" />
         <action
-            android:id="@+id/action_dest_home_to_postContentFragment"
+            android:id="@+id/action_dest_home_to_post_content_fragment"
             app:destination="@id/dest_post_content" />
+        <action
+            android:id="@+id/action_dest_home_to_postDetailFragment"
+            app:destination="@id/dest_post_detail" />
+
     </fragment>
 
     <fragment
@@ -47,6 +51,7 @@
         android:id="@+id/dest_setting"
         android:name="com.wasingun.seller_lounge.ui.setting.SettingFragment"
         android:label="@string/setting" />
+
     <fragment
         android:id="@+id/dest_trend_comparison_result"
         android:name="com.wasingun.seller_lounge.ui.trendcomparison.TrendComparisonResultFragment"
@@ -55,6 +60,7 @@
             android:name="keyword_response"
             app:argType="com.wasingun.seller_lounge.data.model.trendcomparison.KeywordResponse" />
     </fragment>
+
     <fragment
         android:id="@+id/dest_post_content"
         android:name="com.wasingun.seller_lounge.ui.postcontent.PostContentFragment"
@@ -68,5 +74,14 @@
         android:id="@+id/dest_loading_dialog"
         android:name="com.wasingun.seller_lounge.ui.common.LoadingDialogFragment"
         android:label="LoadingDialogFragment" />
+
+    <fragment
+        android:id="@+id/dest_post_detail"
+        android:name="com.wasingun.seller_lounge.ui.postdetail.PostDetailFragment"
+        android:label="PostDetailFragment" >
+        <argument
+            android:name="post"
+            app:argType="com.wasingun.seller_lounge.data.model.post.PostInfo" />
+    </fragment>
 
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,6 +33,9 @@
     <string name="seller_forum">셀러 게시판</string>
     <string name="completed">작성 완료</string>
     <string name="message_wait">잠시만 기다려주세요</string>
+    <string name="error_user_info_update">회원 정보를 갱신할 수 없습니다. 관리자에게 문의 부탁드립니다.</string>
+    <string name="error_writer_info_load">"작성자 정보 로드 오류입니다. 관리자에게 문의 부탁드립니다."</string>
+    <string name="offline_mode">현재 오프라인 모드 입니다. 네트워크 연결 확인을 부탁드립니다.</string>
 
     <string-array name="sort_select">
         <item>정확도순</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -38,11 +38,20 @@
         <item name="android:textSize">11sp</item>
     </style>
 
+    <style name="TextLabelGrey11" parent="TextLabel11">
+        <item name="android:textColor">@color/grey</item>
+    </style>
+
     <style name="TextTitle14" parent="TextAppearance.Material3.TitleSmall">
         <item name="android:textSize">14sp</item>
     </style>
 
-    <style name="TabLayoutTitle" parent="TextAppearance.Design.Tab">
+    <style name="TextBody12" parent="TextAppearance.Material3.BodySmall">
+        <item name="android:textSize">12sp</item>
+        <item name="android:textColor">@color/black</item>
+    </style>
+
+    <style name="TabLayoutText" parent="TextAppearance.Design.Tab">
         <item name="android:textSize">14sp</item>
     </style>
 


### PR DESCRIPTION
1. 게시물 상세화면 레이아웃 구현
2. 유저 정보를 파이어베이스 서버에 업로드 및 상세화면에서 유저 정보를 반환받아 레이아웃에 적용
3. 이미지 리스트를 ViewPager2로 배너형식으로 구현

기타 : 구글 Firebase Authentication에 등록된 유저 정보는 구글 계정을 수정해도 변경되지 않는다는 점을 확인하였으며,
추후 수정이 필요하다면 로그인 이후에 회원정보 등록란을 별도로 생성하여, 유저가 직접 프로필 이미지와 닉네임을 지정하도록 구현하는게 좋다고 생각함.

![image](https://github.com/wasingun/Seller-lounge/assets/121553658/b07be983-f152-437b-9def-7bf17bc061a6)
